### PR TITLE
Fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ The Cloud 66 toobelt is a command line tool to interact with Cloud 66, and is av
 
 Instead of downloading the executable, you also have the option of [building it from source](https://github.com/cloud66/cx/wiki/Building-Cloud-66-toolbelt-(cx)-from-source). You can also add [auto-completing functionality](https://github.com/cloud66/cx/wiki/Setting-up-Auto-complete-for-the-toolbelt) to make your toolbelt use even easier.
 
-Refer to our [documentation](http://help.cloud66.com/cloud-66-toolbelt/introduction.html) for more information about how you can use the toolbelt.
+Refer to our [documentation](http://634-991-907.cloud66.net/toolbelt/toolbelt-introduction) for more information about how you can use the toolbelt.


### PR DESCRIPTION
The documentation link ends up going to `not_found?query=introduction`. It _does_ list `Toolbelt Introduction` as a possible match three results down, but the readme should probably linking to the actual toolbelt intro.